### PR TITLE
Fix broken image url for Yii located inside a sub directory

### DIFF
--- a/controllers/FileController.php
+++ b/controllers/FileController.php
@@ -81,7 +81,7 @@ class FileController extends Controller
 
         $response['files'][] = [
             'url'           => $model->url,
-            'thumbnailUrl'  => $model->getDefaultThumbUrl($bundle->baseUrl),
+            'thumbnailUrl'  => Yii::getAlias('@web').$model->getDefaultThumbUrl($bundle->baseUrl),
             'name'          => $model->filename,
             'type'          => $model->type,
             'size'          => $model->file->size,

--- a/views/file/info.php
+++ b/views/file/info.php
@@ -12,7 +12,7 @@ use pendalf89\filemanager\Module;
 $bundle = FilemanagerAsset::register($this);
 ?>
 
-<?= Html::img($model->getDefaultThumbUrl($bundle->baseUrl)) ?>
+<?= Html::img(Yii::getAlias('@web').$model->getDefaultThumbUrl($bundle->baseUrl)) ?>
 
 <ul class="detail">
     <li><?= $model->type ?></li>


### PR DESCRIPTION
Fix broken image url for Yii located inside sub directory by adding Yii::getAlias('@web') to the image url