### PR TITLE
bugfix: MediafileBehavior::loadModel

### DIFF
--- a/behaviors/MediafileBehavior.php
+++ b/behaviors/MediafileBehavior.php
@@ -74,6 +74,6 @@ class MediafileBehavior extends Behavior
      */
     private function loadModel($id)
     {
-        return Mediafile::findOne($id);
+        return Mediafile::findOne(["url" => $id]);
     }
 }


### PR DESCRIPTION
Russian translation in the end of comment.

Hey! In your example of usage you say that developer has to write widget like this:

```
echo FileInput::widget([
...
    'pasteData' => FileInput::DATA_URL,
...
]);
```
But if developer do so, then MediafileBehavior::findModel method will work wrong. Because it try find model by ID, $id property contents URL instead of ID. And it will find nothing.

So I fixed it and make findModel find by URL, not by ID.

_______

Привет. В твоем примере использования файлового менеджера ты говоришь, что разработчик должен писать виджет вот так:

```
echo FileInput::widget([
...
    'pasteData' => FileInput::DATA_URL,
...
]);
```

Но если разработчик так делает, то метод MediafileBehavior::findModel будет работать неправильно. Потому что он пытается искать модель по ID, но свойство $id содержит URL, а не ID. Он ничего не найдет.

Так что я поправил это и заставил findModel искать по URL, а не по ID.