### PR TITLE
Added 'value' field to TinyMce widget init

### DIFF
--- a/widgets/TinyMCE.php
+++ b/widgets/TinyMCE.php
@@ -61,6 +61,7 @@ class TinyMce extends InputWidget
             'name' => $this->name,
             'model' => $this->model,
             'attribute' => $this->attribute,
+            'value' => $this->value,
             'clientOptions' => $this->clientOptions,
             'options' => $this->options,
         ]);


### PR DESCRIPTION
In pendalf89\filemanager\widgets\TinyMce::init(), the attribute 'value' was not being passed to TinyMceWidget::widget(). As a result, when the widget was being initialized without a model (!$this->hasModel()), the widget would always show a blank value.

My very minor modification solves this problem.