### PR TITLE
Changed file_exists to is_file in delete methods

### DIFF
--- a/models/Mediafile.php
+++ b/models/Mediafile.php
@@ -497,13 +497,13 @@ class Mediafile extends ActiveRecord
         $basePath = Yii::getAlias($routes['basePath']);
 
         foreach ($this->getThumbs() as $thumbUrl) {
-            if(file_exists("$basePath/$thumbUrl")) {
+            if(is_file("$basePath/$thumbUrl")) {
             	unlink("$basePath/$thumbUrl");
             }
         }
         
         $defaultThumbPath = "$basePath/{$this->getDefaultThumbUrl()}";
-        if(file_exists($defaultThumbPath)) {
+        if(is_file($defaultThumbPath)) {
             unlink($defaultThumbPath);
         }
     }
@@ -517,7 +517,7 @@ class Mediafile extends ActiveRecord
     {
         $basePath = Yii::getAlias($routes['basePath']);
         $filePath = "$basePath/{$this->url}";
-        return file_exists($filePath) ? unlink($filePath) : false;
+        return is_file($filePath) ? unlink($filePath) : false;
     }
 
     /**


### PR DESCRIPTION
In Mediafile::deleteThumbs() and Mediafile::deleteFile(), I had added a file_exists condition in my previous pull request. It's more correct to use is_file, because file_exists returns true also for directories, which clearly we don't want to delete here.