### PR TITLE
Fixed migrations and models for working correctly with tablePrefix in…

### DIFF
--- a/migrations/m141129_130551_create_filemanager_mediafile_table.php
+++ b/migrations/m141129_130551_create_filemanager_mediafile_table.php
@@ -7,7 +7,7 @@ class m141129_130551_create_filemanager_mediafile_table extends Migration
 {
     public function up()
     {
-        $this->createTable('filemanager_mediafile', [
+        $this->createTable('{{%filemanager_mediafile}}', [
             'id' => 'pk',
             'filename' => Schema::TYPE_STRING . ' NOT NULL',
             'type' => Schema::TYPE_STRING . ' NOT NULL',
@@ -23,6 +23,6 @@ class m141129_130551_create_filemanager_mediafile_table extends Migration
 
     public function down()
     {
-        $this->dropTable('filemanager_mediafile');
+        $this->dropTable('{{%filemanager_mediafile}}');
     }
 }

--- a/migrations/m141203_173402_create_filemanager_owners_table.php
+++ b/migrations/m141203_173402_create_filemanager_owners_table.php
@@ -7,7 +7,7 @@ class m141203_173402_create_filemanager_owners_table extends Migration
 {
     public function up()
     {
-        $this->createTable('filemanager_owners', [
+        $this->createTable('{{%filemanager_owners}}', [
             'mediafile_id' => Schema::TYPE_INTEGER . ' NOT NULL',
             'owner_id' => Schema::TYPE_INTEGER . ' NOT NULL',
             'owner' => Schema::TYPE_STRING . ' NOT NULL',
@@ -18,6 +18,6 @@ class m141203_173402_create_filemanager_owners_table extends Migration
 
     public function down()
     {
-        $this->dropTable('filemanager_owners');
+        $this->dropTable('{{%filemanager_owners}}');
     }
 }

--- a/migrations/m141203_175538_add_filemanager_owners_ref_mediafile_fk.php
+++ b/migrations/m141203_175538_add_filemanager_owners_ref_mediafile_fk.php
@@ -9,9 +9,9 @@ class m141203_175538_add_filemanager_owners_ref_mediafile_fk extends Migration
     {
         $this->addForeignKey(
             'filemanager_owners_ref_mediafile',
-            'filemanager_owners',
+            '{{%filemanager_owners}}',
             'mediafile_id',
-            'filemanager_mediafile',
+            '{{%filemanager_mediafile}}',
             'id',
             'RESTRICT',
             'RESTRICT'
@@ -20,6 +20,6 @@ class m141203_175538_add_filemanager_owners_ref_mediafile_fk extends Migration
 
     public function down()
     {
-        $this->dropForeignKey('filemanager_owners_ref_mediafile', 'filemanager_owners');
+        $this->dropForeignKey('filemanager_owners_ref_mediafile', '{{%filemanager_owners}}');
     }
 }

--- a/migrations/m160616_000010_add_filemanager_tags.php
+++ b/migrations/m160616_000010_add_filemanager_tags.php
@@ -6,30 +6,30 @@ class m160616_000010_add_filemanager_tags extends Migration
 {
     public function up()
     {
-        $this->createTable('filemanager_tag', [
+        $this->createTable('{{%filemanager_tag}}', [
             'id' => $this->primaryKey(),
             'name' => $this->string(100)->notNull(),
         ]);
 
-        $this->createTable('filemanager_mediafile_tag', [
+        $this->createTable('{{%filemanager_mediafile_tag}}', [
             'mediafile_id' => $this->integer()->notNull(),
             'tag_id' => $this->integer()->notNull(),
         ]);
 
         $this->addForeignKey(
             'filemanager_mediafile_tag_mediafile_id__mediafile_id',
-            'filemanager_mediafile_tag',
+            '{{%filemanager_mediafile_tag}}',
             'mediafile_id',
-            'filemanager_mediafile',
+            '{{%filemanager_mediafile}}',
             'id',
             'CASCADE',
             'CASCADE'
             );
         $this->addForeignKey(
             'filemanager_mediafile_tag_tag_id__tag_id',
-            'filemanager_mediafile_tag',
+            '{{%filemanager_mediafile_tag}}',
             'tag_id',
-            'filemanager_tag',
+            '{{%filemanager_tag}}',
             'id',
             'CASCADE',
             'CASCADE'
@@ -38,7 +38,7 @@ class m160616_000010_add_filemanager_tags extends Migration
 
     public function down()
     {
-        $this->dropTable('filemanager_mediafile_tag');
-        $this->dropTable('filemanager_tag');
+        $this->dropTable('{{%filemanager_mediafile_tag}}');
+        $this->dropTable('{{%filemanager_tag}}');
     }
 }

--- a/models/Mediafile.php
+++ b/models/Mediafile.php
@@ -94,7 +94,7 @@ class Mediafile extends ActiveRecord
      */
     public static function tableName()
     {
-        return 'filemanager_mediafile';
+        return '{{%filemanager_mediafile}}';
     }
 
     /**

--- a/models/Owners.php
+++ b/models/Owners.php
@@ -21,7 +21,7 @@ class Owners extends \yii\db\ActiveRecord
      */
     public static function tableName()
     {
-        return 'filemanager_owners';
+        return '{{%filemanager_owners}}';
     }
 
     /**

--- a/models/Tag.php
+++ b/models/Tag.php
@@ -30,7 +30,7 @@ class Tag extends ActiveRecord
      */
     public static function tableName()
     {
-        return 'filemanager_tag';
+        return '{{%filemanager_tag}}';
     }
 
     /**


### PR DESCRIPTION
Fixed migrations and models for working correctly with tablePrefix instead 'filemanager_mediafile' is now '{{%filemanager_mediafile}}', etc.